### PR TITLE
Remove extraneous `callbackWaitsForEmptyEventLoop` line

### DIFF
--- a/lambda-function.js
+++ b/lambda-function.js
@@ -4,9 +4,6 @@ const lowercaseKeys = require("lowercase-keys");
 
 async function lambdaFunction(probot, event, context) {
   try {
-    // Ends function immediately after callback
-    context.callbackWaitsForEmptyEventLoop = false;
-
     // lowercase all headers to respect headers insensitivity (RFC 7230 $3.2 'Header Fields', see issue #62)
     const headersLowerCase = lowercaseKeys(event.headers);
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -51,10 +51,6 @@ describe("@probot/adapter-aws-lambda-serverless", () => {
 
     await fn(event, context);
 
-    expect(context).toStrictEqual({
-      callbackWaitsForEmptyEventLoop: false,
-    });
-
     expect(mock.activeMocks()).toStrictEqual([]);
   });
 
@@ -87,10 +83,6 @@ describe("@probot/adapter-aws-lambda-serverless", () => {
     };
 
     await fn(event, context);
-
-    expect(context).toStrictEqual({
-      callbackWaitsForEmptyEventLoop: false,
-    });
 
     expect(mock.activeMocks()).toStrictEqual([]);
   });
@@ -125,10 +117,6 @@ describe("@probot/adapter-aws-lambda-serverless", () => {
 
     await fn(event, context);
 
-    expect(context).toStrictEqual({
-      callbackWaitsForEmptyEventLoop: false,
-    });
-
     expect(mock.activeMocks()).toStrictEqual([]);
   });
 
@@ -161,10 +149,6 @@ describe("@probot/adapter-aws-lambda-serverless", () => {
     };
 
     await fn(event, context);
-
-    expect(context).toStrictEqual({
-      callbackWaitsForEmptyEventLoop: false,
-    });
 
     expect(mock.activeMocks()).toStrictEqual([]);
   });


### PR DESCRIPTION
`callbackWaitsForEmptyEventLoop` is only needed for non-async functions (i.e. functions that use callbacks) and therefore can be safely removed from this package.

See https://github.com/probot/adapter-aws-lambda-serverless/issues/78#issuecomment-1062256878 for more details