### PR TITLE
Fix Lambda Error Handling

### DIFF
--- a/lambda-function.js
+++ b/lambda-function.js
@@ -19,7 +19,7 @@ async function lambdaFunction(probot, event, context) {
 
   return {
     statusCode: 200,
-    body: '{"ok":true}',
+    body: JSON.stringify({ ok: true }),
   };
 
 }

--- a/lambda-function.js
+++ b/lambda-function.js
@@ -3,29 +3,23 @@ module.exports = lambdaFunction;
 const lowercaseKeys = require("lowercase-keys");
 
 async function lambdaFunction(probot, event, context) {
-  try {
-    // lowercase all headers to respect headers insensitivity (RFC 7230 $3.2 'Header Fields', see issue #62)
-    const headersLowerCase = lowercaseKeys(event.headers);
+  // lowercase all headers to respect headers insensitivity (RFC 7230 $3.2 'Header Fields', see issue #62)
+  const headersLowerCase = lowercaseKeys(event.headers);
 
-    // this will be simpler once we ship `verifyAndParse()`
-    // see https://github.com/octokit/webhooks.js/issues/379
-    await probot.webhooks.verifyAndReceive({
-      id: headersLowerCase["x-github-delivery"],
-      name: headersLowerCase["x-github-event"],
-      signature:
-        headersLowerCase["x-hub-signature-256"] ||
-        headersLowerCase["x-hub-signature"],
-      payload: event.body,
-    });
+  // this will be simpler once we ship `verifyAndParse()`
+  // see https://github.com/octokit/webhooks.js/issues/379
+  await probot.webhooks.verifyAndReceive({
+    id: headersLowerCase["x-github-delivery"],
+    name: headersLowerCase["x-github-event"],
+    signature:
+      headersLowerCase["x-hub-signature-256"] ||
+      headersLowerCase["x-hub-signature"],
+    payload: event.body,
+  });
 
-    return {
-      statusCode: 200,
-      body: '{"ok":true}',
-    };
-  } catch (error) {
-    return {
-      statusCode: error.status || 500,
-      body: "Error processing GitHub Event",
-    };
-  }
+  return {
+    statusCode: 200,
+    body: '{"ok":true}',
+  };
+
 }

--- a/lambda-function.js
+++ b/lambda-function.js
@@ -25,7 +25,7 @@ async function lambdaFunction(probot, event, context) {
   } catch (error) {
     return {
       statusCode: error.status || 500,
-      error: "ooops",
+      body: "Error processing GitHub Event",
     };
   }
 }


### PR DESCRIPTION
Using a `try`/`catch` block prevents Lambda function errors from being properly interpreted by AWS.

Removing this block will maintain the existing functionality, but allow Probot errors to be properly propagated to AWS Lambda.