### PR TITLE
Restore landing page

### DIFF
--- a/lambda-function.js
+++ b/lambda-function.js
@@ -19,7 +19,7 @@ async function lambdaFunction(probot, event, context) {
 
   return {
     statusCode: 200,
-    body: '{"ok":true}',
+    body: JSON.stringify({ ok: true }),
   };
 
 }

--- a/lambda-function.js
+++ b/lambda-function.js
@@ -3,29 +3,23 @@ module.exports = lambdaFunction;
 const lowercaseKeys = require("lowercase-keys");
 
 async function lambdaFunction(probot, event, context) {
-  try {
-    // lowercase all headers to respect headers insensitivity (RFC 7230 $3.2 'Header Fields', see issue #62)
-    const headersLowerCase = lowercaseKeys(event.headers);
+  // lowercase all headers to respect headers insensitivity (RFC 7230 $3.2 'Header Fields', see issue #62)
+  const headersLowerCase = lowercaseKeys(event.headers);
 
-    // this will be simpler once we ship `verifyAndParse()`
-    // see https://github.com/octokit/webhooks.js/issues/379
-    await probot.webhooks.verifyAndReceive({
-      id: headersLowerCase["x-github-delivery"],
-      name: headersLowerCase["x-github-event"],
-      signature:
-        headersLowerCase["x-hub-signature-256"] ||
-        headersLowerCase["x-hub-signature"],
-      payload: event.body,
-    });
+  // this will be simpler once we ship `verifyAndParse()`
+  // see https://github.com/octokit/webhooks.js/issues/379
+  await probot.webhooks.verifyAndReceive({
+    id: headersLowerCase["x-github-delivery"],
+    name: headersLowerCase["x-github-event"],
+    signature:
+      headersLowerCase["x-hub-signature-256"] ||
+      headersLowerCase["x-hub-signature"],
+    payload: event.body,
+  });
 
-    return {
-      statusCode: 200,
-      body: '{"ok":true}',
-    };
-  } catch (error) {
-    return {
-      statusCode: error.status || 500,
-      body: "Error processing GitHub Event",
-    };
-  }
+  return {
+    statusCode: 200,
+    body: '{"ok":true}',
+  };
+
 }

--- a/lambda-function.js
+++ b/lambda-function.js
@@ -25,7 +25,7 @@ async function lambdaFunction(probot, event, context) {
   } catch (error) {
     return {
       statusCode: error.status || 500,
-      error: "ooops",
+      body: "Error processing GitHub Event",
     };
   }
 }

--- a/lambda-function.js
+++ b/lambda-function.js
@@ -1,8 +1,21 @@
 module.exports = lambdaFunction;
 
 const lowercaseKeys = require("lowercase-keys");
+const { template } = require("./views/probot");
 
 async function lambdaFunction(probot, event, context) {
+
+  if (event.httpMethod === "GET" && event.path === "/probot") {
+    const res = {
+      statusCode: 200,
+      headers: {
+        "Content-Type": "text/html",
+      },
+      body: template,
+    };
+    return res;
+  }
+
   // lowercase all headers to respect headers insensitivity (RFC 7230 $3.2 'Header Fields', see issue #62)
   const headersLowerCase = lowercaseKeys(event.headers);
 

--- a/views/probot.js
+++ b/views/probot.js
@@ -25,7 +25,6 @@ module.exports.template = `
         <h4 class="alt-h4 text-gray-light">Need help?</h4>
         <div class="d-flex flex-justify-center mt-2">
           <a href="https://probot.github.io/docs/" class="btn btn-outline mr-2">Documentation</a>
-          <a href="https://probot-slackin.herokuapp.com/" class="btn btn-outline">Chat on Slack</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
This PR restores the static landing page functionality (which is useful as a health check) that was lost during the `v1` to `v2` transition.

It also removes a dead link from the landing page.

**Note:** To avoid merge conflicts, I've based these changes on #91. That PR should be merged first.