### PR TITLE
Remove `webhooks` keyword ambiguity from `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ const {
   createProbot,
 } = require("@probot/adapter-aws-lambda-serverless");
 const appFn = require("./");
-module.exports.webhooks = createLambdaFunction(appFn, {
+module.exports.lambdaFn = createLambdaFunction(appFn, {
   probot: createProbot(),
 });
 ```
@@ -39,8 +39,8 @@ provider:
     LOG_LEVEL: debug
 
 functions:
-  webhooks:
-    handler: handler.webhooks
+  probot:
+    handler: handler.lambdaFn
     events:
       - httpApi:
           path: /api/github/webhooks


### PR DESCRIPTION
The keyword `webhooks` is used in a lot of different places in the `README.md` file.

This makes it hard to determine which variables, function names, paths, etc. are related.

This PR updates `README.md` to remove that ambiguity.