### PR TITLE
Fix Types

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,10 @@
 name: Test
-
-on: [push]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize]
 
 jobs:
   test_matrix:

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 import { Probot } from "probot";
-import { APIGatewayProxyHandler } from "aws-lambda";
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import { ApplicationFunction } from "probot/lib/types";
 
 export * from "probot";
@@ -7,4 +7,4 @@ export * from "probot";
 export function createLambdaFunction(
   app: ApplicationFunction,
   options: { probot: Probot }
-): APIGatewayProxyHandler;
+): (event: APIGatewayProxyEvent) => Promise<APIGatewayProxyResult>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,9 @@
 import { Probot } from "probot";
-import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
+import {
+  APIGatewayProxyEvent,
+  APIGatewayProxyResult,
+  Context,
+} from "aws-lambda";
 import { ApplicationFunction } from "probot/lib/types";
 
 export * from "probot";
@@ -7,4 +11,7 @@ export * from "probot";
 export function createLambdaFunction(
   app: ApplicationFunction,
   options: { probot: Probot }
-): (event: APIGatewayProxyEvent) => Promise<APIGatewayProxyResult>;
+): (
+  event: APIGatewayProxyEvent,
+  context: Context
+) => Promise<APIGatewayProxyResult>;

--- a/lambda-function.js
+++ b/lambda-function.js
@@ -3,7 +3,7 @@ module.exports = lambdaFunction;
 const lowercaseKeys = require("lowercase-keys");
 const { template } = require("./views/probot");
 
-async function lambdaFunction(probot, event, context) {
+async function lambdaFunction(probot, event) {
   if (event.httpMethod === "GET" && event.path === "/probot") {
     const res = {
       statusCode: 200,

--- a/lambda-function.js
+++ b/lambda-function.js
@@ -3,7 +3,7 @@ module.exports = lambdaFunction;
 const lowercaseKeys = require("lowercase-keys");
 const { template } = require("./views/probot");
 
-async function lambdaFunction(probot, event) {
+async function lambdaFunction(probot, event, context) {
   if (event.httpMethod === "GET" && event.path === "/probot") {
     const res = {
       statusCode: 200,


### PR DESCRIPTION
This PR fixes the types in `index.d.ts`.

Currently, the type signature for `createLambdaFunction` returns a type of `APIGatewayProxyHandler` which doesn't match its implementation.

See the source code for `APIGatewayProxyHandler` here:

- `APIGatewayProxyHandler` (which ultimately uses `Handler`, below) - https://github.com/DefinitelyTyped/DefinitelyTyped/blob/b384d9e82713dc8400a1289eeb9be7f2fc467390/types/aws-lambda/trigger/api-gateway-proxy.d.ts#L12
- `Handler`  - https://github.com/DefinitelyTyped/DefinitelyTyped/blob/b384d9e82713dc8400a1289eeb9be7f2fc467390/types/aws-lambda/handler.d.ts#L83-L88
  - this type-signature requires three arguments and has a return type of `void | Promise<APIGatewayProxyResult>`. both of these items don't match `lambda-function.js`, which only requires two arguments and returns a type of `Promise<APIGatewayProxyResult>`

Instead of using `APIGatewayProxyHandler`, I switched the return type to simply be a function which accepts a single `APIGatewayProxyEvent` argument and returns a `Promise<APIGatewayProxyResult>` type.

This change also means the unused `context` argument in `createLambdaFunction` can be removed.