### PR TITLE
fix(typescript): add types for `createLambdaFunction()`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,6 +3,8 @@ import {
   APIGatewayProxyEvent,
   APIGatewayProxyResult,
   Context,
+  LambdaFunctionURLEvent,
+  LambdaFunctionURLResult,
 } from "aws-lambda";
 import { ApplicationFunction } from "probot/lib/types";
 
@@ -15,3 +17,11 @@ export function createLambdaFunction(
   event: APIGatewayProxyEvent,
   context: Context
 ) => Promise<APIGatewayProxyResult>;
+
+export function createLambdaFunction(
+  app: ApplicationFunction,
+  options: { probot: Probot }
+): (
+  event: LambdaFunctionURLEvent,
+  context: Context
+) => Promise<LambdaFunctionURLResult>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-development",
       "license": "ISC",
       "dependencies": {
-        "@types/aws-lambda": "^8.10.85",
+        "@types/aws-lambda": "^8.10.147",
         "lowercase-keys": "^2.0.0",
         "probot": "^13.3.0"
       },
@@ -1546,9 +1546,9 @@
       }
     },
     "node_modules/@types/aws-lambda": {
-      "version": "8.10.109",
-      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.109.tgz",
-      "integrity": "sha512-/ME92FneNyXQzrAfcnQQlW1XkCZGPDlpi2ao1MJwecN+6SbeonKeggU8eybv1DfKli90FAVT1MlIZVXfwVuCyg=="
+      "version": "8.10.147",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.147.tgz",
+      "integrity": "sha512-nD0Z9fNIZcxYX5Mai2CTmFD7wX7UldCkW2ezCF8D1T5hdiLsnTWDGRpfRYntU6VjTdLQjOvyszru7I1c1oCQew=="
     },
     "node_modules/@types/babel__core": {
       "version": "7.1.20",
@@ -6972,9 +6972,9 @@
       }
     },
     "@types/aws-lambda": {
-      "version": "8.10.109",
-      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.109.tgz",
-      "integrity": "sha512-/ME92FneNyXQzrAfcnQQlW1XkCZGPDlpi2ao1MJwecN+6SbeonKeggU8eybv1DfKli90FAVT1MlIZVXfwVuCyg=="
+      "version": "8.10.147",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.147.tgz",
+      "integrity": "sha512-nD0Z9fNIZcxYX5Mai2CTmFD7wX7UldCkW2ezCF8D1T5hdiLsnTWDGRpfRYntU6VjTdLQjOvyszru7I1c1oCQew=="
     },
     "@types/babel__core": {
       "version": "7.1.20",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "repository": "github:probot/adapter-aws-lambda-serverless",
   "dependencies": {
-    "@types/aws-lambda": "^8.10.85",
+    "@types/aws-lambda": "^8.10.147",
     "lowercase-keys": "^2.0.0",
     "probot": "^13.3.0"
   },


### PR DESCRIPTION
This PR adds types for Lambda function URLs.

Details about Lambda function URLs can be found below:

- https://aws.amazon.com/blogs/aws/announcing-aws-lambda-function-urls-built-in-https-endpoints-for-single-function-microservices/
- https://docs.aws.amazon.com/lambda/latest/dg/urls-configuration.html

No changes should be necessary to the `createLambdaFunction` implementation since the expected arguments and return types are nearly identical.