### PR TITLE
fix(typescript): fix types for `createLambdaFunction()`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -14,14 +14,6 @@ export function createLambdaFunction(
   app: ApplicationFunction,
   options: { probot: Probot }
 ): (
-  event: APIGatewayProxyEvent,
+  event: APIGatewayProxyEvent | LambdaFunctionURLEvent,
   context: Context
-) => Promise<APIGatewayProxyResult>;
-
-export function createLambdaFunction(
-  app: ApplicationFunction,
-  options: { probot: Probot }
-): (
-  event: LambdaFunctionURLEvent,
-  context: Context
-) => Promise<LambdaFunctionURLResult>;
+) => Promise<APIGatewayProxyResult | LambdaFunctionURLResult>;


### PR DESCRIPTION
This PR fixes the types that were introduced in #132.

Sorry for the noise!